### PR TITLE
fix missing key react warning

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -103,6 +103,7 @@ export const onPreRenderHTML = (
     replaceHeadComponents([
       <link
         rel="amphtml"
+        key="gatsby-plugin-amp-amphtml-link"
         href={interpolate(relAmpHtmlPattern, {
           canonicalBaseUrl,
           pathIdentifier,


### PR DESCRIPTION
fixes this warning:

```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <head>. See https://fb.me/react-warning-keys for more information.
    in link (at gatsby-ssr.js:103)
    in HTML
```