### PR TITLE
updating pathIdentifier in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Add the plugin to the plugins array in your `gatsby-config.js`
     canonicalBaseUrl: 'http://www.example.com/',
     components: ['amp-form'],
     excludedPaths: ['/404*', '/'],
-    pathIdentifier: '/amp/',
+    pathIdentifier: '/amp',
     relAmpHtmlPattern: '{{canonicalBaseUrl}}{{pathname}}{{pathIdentifier}}',
     useAmpClientIdApi: true,
   },


### PR DESCRIPTION
https://github.com/jafaircl/gatsby-plugin-amp/issues/34

just use `"/amp",` remove last slash. It will work.

example: 
```javascript
    {
      resolve: `gatsby-plugin-amp`,
      options: {
        analytics: {
          type: "gtag",
          dataCredentials: "include",
          config: {
            vars: {
              gtag_id: "UA-XX-1",
              config: {
                "UA-XX-1": {
                  page_location: "{{pathname}}",
                },
              },
            },
          },
        },
        canonicalBaseUrl: "http://www.example.com/",
        components: ["amp-form"],
        excludedPaths: ["/404*", "/"],
        pathIdentifier: **"/amp",**
        relAmpHtmlPattern: "{{canonicalBaseUrl}}{{pathname}}{{pathIdentifier}}",
        useAmpClientIdApi: true,
      },
```