### PR TITLE
remove 'gatsby-image-style-noscript' generated by 'gatsby-image-plugin'

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -84,7 +84,8 @@ export const onPreRenderHTML = (
         x =>
           x.type !== "style" &&
           (x.type !== "script" || x.props.type === "application/ld+json") &&
-          x.key !== "TypographyStyle"
+          x.key !== "TypographyStyle" &&
+          x.key !== "gatsby-image-style-noscript"
       )
     ]);
     replacePreBodyComponents([


### PR DESCRIPTION
`gatsby-image-plugin` injects <noscript><style> tag as part of their support for lazy-loading images, making the amp page invalid.
This patch removes the `gatsby-image-style-noscript` entirely from amp head content